### PR TITLE
The user can now select the pronunciations to import (UK, US)

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -279,6 +279,28 @@ class AddonConfigWindow(QDialog):
         self.ledit_cookie.setText(self.config['cookie'] if self.config['cookie'] else '')
         h_layout.addWidget(self.ledit_cookie,QtCore.Qt.AlignRight)
         layout.addLayout(h_layout,QtCore.Qt.AlignTop)
+
+        # Pronunciation UK
+        h_layout = QHBoxLayout()
+        h_label = QLabel()
+        h_label.setText('Pronunciation UK:')
+        h_layout.addWidget(h_label)
+        h_layout.addStretch()        
+        self.cb_pronunciation_uk = QCheckBox()
+        self.cb_pronunciation_uk.setChecked(self.config['pronunciation_uk'] if 'pronunciation_uk' in self.config else True)
+        h_layout.addWidget(self.cb_pronunciation_uk,QtCore.Qt.AlignRight)
+        layout.addLayout(h_layout,QtCore.Qt.AlignTop)
+
+        # Pronunciation US
+        h_layout = QHBoxLayout()
+        h_label = QLabel()
+        h_label.setText('Pronunciation US:')
+        h_layout.addWidget(h_label)
+        h_layout.addStretch()        
+        self.cb_pronunciation_us = QCheckBox()
+        self.cb_pronunciation_us.setChecked(self.config['pronunciation_us'] if 'pronunciation_us' in self.config else True)
+        h_layout.addWidget(self.cb_pronunciation_us,QtCore.Qt.AlignRight)
+        layout.addLayout(h_layout,QtCore.Qt.AlignTop)
         
         # Wordlist IDs
         h_layout = QVBoxLayout()
@@ -348,6 +370,8 @@ class AddonConfigWindow(QDialog):
     def btn_Ok(self):
         # Fill config dict with current settings and write them to file
         self.config['cookie'] = self.ledit_cookie.text()
+        self.config['pronunciation_uk'] = self.cb_pronunciation_uk.isChecked()
+        self.config['pronunciation_us'] = self.cb_pronunciation_us.isChecked()
         wl = []
         for i in self.iterAllItems(self.wordlist_list):
             wl.append(i.text())

--- a/utils.py
+++ b/utils.py
@@ -18,21 +18,29 @@ fields = ['Word','Examples','Definition','Audio','Picture','Pronunciation','Gram
 
 def fill_note(word_entry, note):
 
+    config = get_config()
+    pronunciation_uk = config['pronunciation_uk'] if 'pronunciation_uk' in config else True
+    pronunciation_us = config['pronunciation_us'] if 'pronunciation_us' in config else True
+
     note['Word']            = word_entry.word_title
     note['Examples']        = "<br> ".join(word_entry.word_examples)
     note['Definition']      = word_entry.word_specific
-    note['Pronunciation']   = word_entry.word_pro_uk + ' ' + word_entry.word_pro_us
+    note['Pronunciation']   = ""
+    if pronunciation_uk:
+        note['Pronunciation'] += word_entry.word_pro_uk + ' ' 
+    if pronunciation_us:
+        note['Pronunciation'] += word_entry.word_pro_us
     note['Grammar']         = word_entry.word_part_of_speech
     note['Meaning']         = word_entry.word_general
     audio_field = ''
-    if word_entry.word_uk_media:
+    if word_entry.word_uk_media and pronunciation_uk:
         try:
             f_entry = get_file_entry(word_entry.word_uk_media,note['Word'])
             audio_field = audio_field + '[sound:' + unmunge_to_mediafile(f_entry)+'] '
         except :
             pass
     try:
-        if word_entry.word_us_media:
+        if word_entry.word_us_media and pronunciation_us:
             f_entry = get_file_entry(word_entry.word_us_media,note['Word'])
             audio_field = audio_field + '[sound:' + unmunge_to_mediafile(f_entry)+'] '
     except :
@@ -204,7 +212,7 @@ def get_config():
                 config = json.loads(f.read())
         except IOError:
             try:
-                config = {'cookie':''}
+                config = {'cookie':'', 'pronunciation_uk': True, 'pronunciation_us': True}
                 config_file = os.path.join(get_addon_dir(), 'config.json')
                 with open(config_file, 'w') as f:
                     json.dump(config, f, sort_keys=True, indent=2)
@@ -231,6 +239,8 @@ def update_config(config):
 def get_config_dict():
     config = {}
     config['cookie'] = ''
+    config['pronunciation_uk'] = True
+    config['pronunciation_us'] = True
     return config
 
 def find_note_with_url_pictures(AddonDialog):


### PR DESCRIPTION
### User experience
The user configures the pronunciations to import through the settings dialog:
![anki_cambridge_settings](https://user-images.githubusercontent.com/1282491/189523736-46abf30c-4694-45de-8858-69d1216aedaa.png)

When both the checkboxes are unchecked, the add-on doesn't create the sound card.

### Implementation details
The pronunciations to import are stored in the config JSON as two boolean fields `pronunciation_uk` and `pronunciation_us`:
```
{
'cookie':'', 
'pronunciation_uk': true, 
'pronunciation_us': true
}
```
If the field is missing, the add-on would import the pronunciation.

### Issue
This pull request should resolve the request #13 